### PR TITLE
Fix URL Scheme prefix

### DIFF
--- a/LineSDKStarterObjC/LineSDKStarterObjC/Info.plist
+++ b/LineSDKStarterObjC/LineSDKStarterObjC/Info.plist
@@ -25,7 +25,7 @@
 			<string>None</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>line3rdpb.{YOUR_URL_SCHEME}</string>
+				<string>line3rdp.{YOUR_URL_SCHEME}</string>
 			</array>
 		</dict>
 	</array>

--- a/LineSDKStarterSwift/LineSDKStarterSwift/Info.plist
+++ b/LineSDKStarterSwift/LineSDKStarterSwift/Info.plist
@@ -25,7 +25,7 @@
 			<string>None</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>line3rdpb.{YOUR_URL_SCHEME}</string>
+				<string>line3rdp.{YOUR_URL_SCHEME}</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
I think the prefix must be `line3rdp.`.

Which is correct?
- In starter's repository: `line3rdpb.{YOUR_URL_SCHEME}`
- In SDK's developer document: `line3rdp.{YOUR_URL_SCHEME}`
