### PR TITLE
Remove LineAdapter.plist(unused file)

### DIFF
--- a/LineSDKStarterObjC/LineSDKStarterObjC.xcodeproj/project.pbxproj
+++ b/LineSDKStarterObjC/LineSDKStarterObjC.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		75EE41DA1B42A9150019DA95 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 75EE41D91B42A9150019DA95 /* Images.xcassets */; };
 		75EE41DD1B42A9150019DA95 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 75EE41DB1B42A9150019DA95 /* LaunchScreen.xib */; };
 		75EE41F31B42A9510019DA95 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75EE41F21B42A9510019DA95 /* CoreTelephony.framework */; };
-		75EE41FD1B42A97C0019DA95 /* LineAdapter.plist in Resources */ = {isa = PBXBuildFile; fileRef = 75EE41FC1B42A97C0019DA95 /* LineAdapter.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,7 +28,6 @@
 		75EE41D91B42A9150019DA95 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		75EE41DC1B42A9150019DA95 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		75EE41F21B42A9510019DA95 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
-		75EE41FC1B42A97C0019DA95 /* LineAdapter.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = LineAdapter.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,7 +78,6 @@
 			children = (
 				75EE41F21B42A9510019DA95 /* CoreTelephony.framework */,
 				75EE41CD1B42A9150019DA95 /* Info.plist */,
-				75EE41FC1B42A97C0019DA95 /* LineAdapter.plist */,
 				75EE41CE1B42A9150019DA95 /* main.m */,
 			);
 			name = "Supporting Files";
@@ -145,7 +142,6 @@
 			files = (
 				75EE41D81B42A9150019DA95 /* Main.storyboard in Resources */,
 				75EE41DD1B42A9150019DA95 /* LaunchScreen.xib in Resources */,
-				75EE41FD1B42A97C0019DA95 /* LineAdapter.plist in Resources */,
 				75EE41DA1B42A9150019DA95 /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LineSDKStarterSwift/LineSDKStarterSwift.xcodeproj/project.pbxproj
+++ b/LineSDKStarterSwift/LineSDKStarterSwift.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		75EE41911B4297210019DA95 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		75EE41931B4297210019DA95 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		75EE41961B4297210019DA95 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
-		75EE41B41B4299E90019DA95 /* LineAdapter.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = LineAdapter.plist; sourceTree = "<group>"; };
 		75EE41B61B429A970019DA95 /* LineSDKStarterSwift-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LineSDKStarterSwift-Bridging-Header.h"; sourceTree = "<group>"; };
 		75EE41BA1B429E190019DA95 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		75EE41BE1B42A7650019DA95 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
@@ -74,7 +73,6 @@
 			children = (
 				75EE41BE1B42A7650019DA95 /* CoreTelephony.framework */,
 				75EE418B1B4297210019DA95 /* Info.plist */,
-				75EE41B41B4299E90019DA95 /* LineAdapter.plist */,
 				75EE41B61B429A970019DA95 /* LineSDKStarterSwift-Bridging-Header.h */,
 			);
 			name = "Supporting Files";


### PR DESCRIPTION
LineAdapter.plist was merged to Info.plist and became deprecated on the LineAdapter3.2.